### PR TITLE
Add script to manually adjust layer versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+tmp/

--- a/README.md
+++ b/README.md
@@ -36,3 +36,25 @@ This will result in layers: `rotel-extension:1`, `rotel-extension:2`, etc.
 rely on the auto-incrementing values to match the release name if we follow the same incrementing version scheme.
 
 For the *arm64* architecture, the extension is named `rotel-extension-arm64-alpha` and `rotel-extension-arm64`.
+
+_There may be some gaps in release numbers due to trying to keep version numbers and lambda layer version numbers in sync._
+
+## Manual deploy
+
+The Lambda layer version numbers can sometimes require manual adjustment to ensure they align across regions. They can
+be incremented by manually deploying versions of the layer until the version matches the required level. Follow this process
+to raise a layer version number to a specific value.
+
+1. Pick a Rotel release build that you want to deploy, including the right architecture.
+1. Find the Github action run for that tag, for example: [v1-alpha](https://github.com/streamfold/rotel-lambda-extension/actions/runs/14323997150).
+1. Download the artifact you want to deploy to raise the layer version number.
+1. Run: `rm -rf target/lambda && mkdir -p target/lambda && unzip extensions-<...>.zip -d target/lambda`
+1. Login to the aws cli via sso
+1. Run the following script:
+```shell
+./scripts/manual-deploy.sh <arch> <layer-name> <region> <how-many>
+```
+  - `arch`: either _x86-64_ or _arm64_
+  - `layer-name`: full name of layer including arch and version suffix, examples: `rotel-extension-arm64-alpha`, `rotel-extension-alpha`, etc. (check Lambda console in case)
+  - `region`: region to deploy to
+  - `how-many`: how many times to deploy. If the current version is 3 and you need it to be 10, you'd pass "7" to deploy 7 times (3 + 7 = 10)

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ $# -ne 4 ]; then
+  echo "Usage: $0 arch layer-name region how-many"
+  exit 1
+fi
+
+set -e
+
+ARCH="$1"
+shift
+
+if [ "$ARCH" != "x86-64" -a "$ARCH" != "arm64" ]; then
+  echo "Invalid arch: $ARCH"
+  exit 1
+fi
+
+LAYER_NAME="$1"
+shift
+
+REGION="$1"
+shift
+
+HOW_MANY="$1"
+shift
+
+echo "Deploying arch $ARCH as $LAYER_NAME to $REGION $HOW_MANY times...sleeping 5 seconds"
+sleep 5
+
+export AWS_PROFILE=AdministratorAccess-418653438961
+
+OUT=/tmp/lambda-deploy.out
+
+rm -f $OUT
+for ((i = 0; i < $HOW_MANY; ++i)); do
+  echo "Deploying $LAYER_NAME for iter $i"
+  echo
+  AWS_REGION="$REGION" cargo lambda deploy --extension --region "$REGION" --lambda-dir "target/lambda/${ARCH}" \
+    --binary-name rotel-extension "$LAYER_NAME" | tee -a $OUT
+done
+
+./scripts/publish-lambda-version.sh $( grep 'extension arn' "$OUT"  | awk '{print $4}' )
+
+


### PR DESCRIPTION
Hack to simply deploy a layer multiple times so that version numbers stay in sync. Unfortunately removing layers does not reset the version number counter.

Completes: STR-3261