### PR TITLE
Bump for ch-logs release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1892,8 +1892,8 @@ dependencies = [
 
 [[package]]
 name = "rotel"
-version = "0.0.1-alpha4"
-source = "git+https://github.com/streamfold/rotel?rev=1103910888a6209cf6ef22770630ec8821884b73#1103910888a6209cf6ef22770630ec8821884b73"
+version = "0.0.1-alpha5"
+source = "git+https://github.com/streamfold/rotel?rev=e4381af9161b42c05c6e2b647e604f875fb63d83#e4381af9161b42c05c6e2b647e604f875fb63d83"
 dependencies = [
  "bstr",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustls = "0.23.20"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-appender = "0.2.3"
 tower = { version = "0.5.2", features = ["retry", "timeout"] }
-rotel = { git = "https://github.com/streamfold/rotel", rev = "1103910888a6209cf6ef22770630ec8821884b73" }
+rotel = { git = "https://github.com/streamfold/rotel", rev = "e4381af9161b42c05c6e2b647e604f875fb63d83" }
 opentelemetry-proto = "0.29.0"
 chrono = "0.4.40"
 opentelemetry-semantic-conventions = { version = "0.29.0", features = ["semconv_experimental"] }


### PR DESCRIPTION
Bumps to latest rotel with Clickhouse logs support + bumps crossbeam-channel.