### PR TITLE
Read values from Parameter Store as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       - name: run test
         env:
           TEST_SECRETSMANAGER_ARNS: ${{ secrets.TEST_SECRETSMANAGER_ARNS }}
+          TEST_PARAMSTORE_ARNS: ${{ secrets.TEST_PARAMSTORE_ARNS }}
+          TEST_ENVSECRET_ARNS: ${{ secrets.TEST_ENVSECRET_ARNS }}
         run: |
           cargo test --target ${{ matrix.target }} --verbose
 

--- a/README.md
+++ b/README.md
@@ -63,23 +63,45 @@ allowing you to set the secret values in your AWS Lambda function definition and
 
 ### Secrets
 
-Secret values can be retrieved from [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) by specifying the full
+Secret values can be retrieved from **[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)** or from **[AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)** by specifying the full
 ARN of the stored secret as the environment variable name. This allows you to keep secret values out of configuration
 files.
 
-For example, the following env file will load the API key from the secret ARN. Ensure that your Lambda has IAM permissions
-for the [GetSecretValue](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html) action.
+**AWS Secrets Manager Example**
+
 ```shell
 ROTEL_OTLP_EXPORTER_ENDPOINT=https://api.axiom.co
 ROTEL_OTLP_EXPORTER_PROTOCOL=http
 ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:secretsmanager:us-east-1:123377354456:secret:axiom-api-key-r1l7G9},X-Axiom-Dataset=${AXIOM_DATASET}"
 ```
 
-_Make sure to set a plaintext secret string value for the secret. Only secrets stored in AWS Secrets Manager are supported at the moment._
+**AWS Parameter Store Example**
 
-**NOTE**: AWS Secrets Manager API calls can increase cold start latency by 100-150 ms even when made within the same region, so be
-mindful of that impact when retrieving secrets. Secrets are only retrieved on initialization, so subsequent invocations are
-not impacted.
+```shell
+ROTEL_OTLP_EXPORTER_ENDPOINT=https://api.axiom.co
+ROTEL_OTLP_EXPORTER_PROTOCOL=http
+ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${arn:aws:ssm:us-east-1:123377354456:parameter/axiom-api-key},X-Axiom-Dataset=${AXIOM_DATASET}"
+```
+
+**Permissions:**
+
+You must ensure the following IAM permissions exist for your Lambda runtime execution role:
+
+* Secrets Manager
+  - [`secretsmanager:GetSecretValue`](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html)
+  - [`secretsmanager:BatchGetSecretValue`](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_BatchGetSecretValue.html)
+* Parameter Store
+  - [`ssm:GetParameters`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html)
+
+Secrets must be stored as a plaintext secret string value for AWS Secrets Manager and as a SecureString for AWS Parameter Store. 
+
+**NOTE**:
+
+AWS API calls can increase cold start latency by 100-150 ms even when made within the same region, so be
+mindful of that impact when retrieving secrets. Secrets are retrieved in batches up to 10, so retrieving
+multiple secret values should not take longer than a single secret.
+
+Secrets are only retrieved on initialization, so subsequent invocations are not impacted.
 
 ## Disabling CloudWatch Logs
 

--- a/src/aws_api/auth.rs
+++ b/src/aws_api/auth.rs
@@ -13,6 +13,7 @@ pub trait Clock {
     fn now(&self) -> DateTime<Utc>;
 }
 
+#[derive(Default)]
 pub struct SystemClock;
 
 impl Clock for SystemClock {

--- a/src/aws_api/client.rs
+++ b/src/aws_api/client.rs
@@ -1,5 +1,6 @@
 use crate::aws_api::config::AwsConfig;
 use crate::aws_api::error::Error;
+use crate::aws_api::paramstore::ParameterStore;
 use crate::aws_api::secretsmanager::SecretsManager;
 use crate::util::http::response_string;
 use bytes::Bytes;
@@ -31,6 +32,11 @@ impl AwsClient {
     /// Get an instance of the SecretsManager service
     pub fn secrets_manager(&self) -> SecretsManager {
         SecretsManager::new(self)
+    }
+
+    /// Get an instance of the ParameterStore service
+    pub fn parameter_store(&self) -> ParameterStore {
+        ParameterStore::new(self)
     }
 
     pub async fn perform(&self, req: Request<Full<Bytes>>) -> Result<Bytes, Error> {

--- a/src/aws_api/error.rs
+++ b/src/aws_api/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     SignatureError(String),
     SerdeError(serde_json::Error),
     AwsError { code: String, message: String },
+    InvalidSecrets(Vec<String>),
 }
 
 impl fmt::Display for Error {
@@ -27,6 +28,9 @@ impl fmt::Display for Error {
             Error::HttpResponseError(e) => write!(f, "Failed to parse HTTP response: {}", e),
             Error::HttpResponseErrorParse(e) => write!(f, "Failed to parse HTTP response: {}", e),
             Error::UriParseError(e) => write!(f, "Unable to parse endpoint url: {}", e),
+            Error::InvalidSecrets(params) => {
+                write!(f, "Unable to lookup secret values: {:?}", params)
+            }
         }
     }
 }

--- a/src/aws_api/mod.rs
+++ b/src/aws_api/mod.rs
@@ -1,6 +1,14 @@
-mod arn;
+pub mod arn;
 mod auth;
 pub mod client;
 pub mod config;
 mod error;
+mod paramstore;
 mod secretsmanager;
+
+pub const SECRETS_MANAGER_SERVICE: &str = "secretsmanager";
+pub const PARAM_STORE_SERVICE: &str = "ssm";
+
+// This is the minimum of what SecretsManager and ParamStore supports for
+// batch calls. It would be surprising to have > 10 secrets.
+pub const MAX_LOOKUP_LEN: usize = 10;

--- a/src/aws_api/paramstore.rs
+++ b/src/aws_api/paramstore.rs
@@ -36,9 +36,9 @@ pub struct Parameter {
     #[serde(rename = "ARN")]
     pub arn: Option<String>,
 
-    /// The data type of the parameter, such as text, aws:ec2:image, or aws:tag-specification.
-    #[serde(rename = "DataType")]
-    pub data_type: Option<String>,
+    // /// The data type of the parameter, such as text, aws:ec2:image, or aws:tag-specification.
+    // #[serde(rename = "DataType")]
+    // pub data_type: Option<String>,
 
     /// The last modification date of the parameter.
     #[serde(rename = "LastModifiedDate")]
@@ -48,13 +48,13 @@ pub struct Parameter {
     #[serde(rename = "Name")]
     pub name: String,
 
-    /// The unique identifier for the parameter version.
-    #[serde(rename = "Selector")]
-    pub selector: Option<String>,
+    // /// The unique identifier for the parameter version.
+    // #[serde(rename = "Selector")]
+    // pub selector: Option<String>,
 
-    /// The parameter source.
-    #[serde(rename = "SourceResult")]
-    pub source_result: Option<String>,
+    // /// The parameter source.
+    // #[serde(rename = "SourceResult")]
+    // pub source_result: Option<String>,
 
     /// The parameter type.
     #[serde(rename = "Type")]
@@ -68,9 +68,9 @@ pub struct Parameter {
     #[serde(rename = "Version")]
     pub version: Option<i64>,
 
-    /// Tags associated with the parameter.
-    #[serde(rename = "Tags")]
-    pub tags: Option<HashMap<String, String>>,
+    // /// Tags associated with the parameter.
+    // #[serde(rename = "Tags")]
+    // pub tags: Option<HashMap<String, String>>,
 }
 
 impl<'a> ParameterStore<'a> {

--- a/src/aws_api/paramstore.rs
+++ b/src/aws_api/paramstore.rs
@@ -39,7 +39,6 @@ pub struct Parameter {
     // /// The data type of the parameter, such as text, aws:ec2:image, or aws:tag-specification.
     // #[serde(rename = "DataType")]
     // pub data_type: Option<String>,
-
     /// The last modification date of the parameter.
     #[serde(rename = "LastModifiedDate")]
     pub last_modified_date: Option<f64>,
@@ -55,7 +54,6 @@ pub struct Parameter {
     // /// The parameter source.
     // #[serde(rename = "SourceResult")]
     // pub source_result: Option<String>,
-
     /// The parameter type.
     #[serde(rename = "Type")]
     pub type_: String,
@@ -67,7 +65,6 @@ pub struct Parameter {
     /// The parameter version.
     #[serde(rename = "Version")]
     pub version: Option<i64>,
-
     // /// Tags associated with the parameter.
     // #[serde(rename = "Tags")]
     // pub tags: Option<HashMap<String, String>>,

--- a/src/aws_api/paramstore.rs
+++ b/src/aws_api/paramstore.rs
@@ -1,3 +1,4 @@
+use crate::aws_api::PARAM_STORE_SERVICE;
 use crate::aws_api::arn::AwsArn;
 use crate::aws_api::auth::{AwsRequestSigner, SystemClock};
 use crate::aws_api::client::AwsClient;
@@ -74,7 +75,7 @@ impl<'a> ParameterStore<'a> {
     pub(crate) fn new(client: &'a AwsClient) -> Self {
         Self {
             client,
-            service_name: "ssm",
+            service_name: PARAM_STORE_SERVICE,
         }
     }
 

--- a/src/aws_api/secretsmanager.rs
+++ b/src/aws_api/secretsmanager.rs
@@ -1,3 +1,4 @@
+use crate::aws_api::SECRETS_MANAGER_SERVICE;
 use crate::aws_api::arn::AwsArn;
 use crate::aws_api::auth::{AwsRequestSigner, SystemClock};
 use crate::aws_api::client::AwsClient;
@@ -62,7 +63,7 @@ impl<'a> SecretsManager<'a> {
     pub(crate) fn new(client: &'a AwsClient) -> Self {
         Self {
             client,
-            service_name: "secretsmanager",
+            service_name: SECRETS_MANAGER_SERVICE,
         }
     }
 

--- a/src/aws_api/secretsmanager.rs
+++ b/src/aws_api/secretsmanager.rs
@@ -41,7 +41,7 @@ pub struct ResponseSecret {
     pub arn: Option<String>,
 
     #[serde(rename = "CreatedDate")]
-    pub created_date: i64,
+    pub created_date: f64,
 
     #[serde(rename = "Name")]
     pub name: String,

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,7 @@
+use crate::aws_api::arn::AwsArn;
 use crate::aws_api::client::AwsClient;
 use crate::aws_api::config::AwsConfig;
+use crate::aws_api::{MAX_LOOKUP_LEN, PARAM_STORE_SERVICE, SECRETS_MANAGER_SERVICE};
 use regex::Regex;
 use std::collections::HashMap;
 use tokio::time::Instant;
@@ -70,22 +72,67 @@ pub async fn resolve_secrets(
     let secrets_start = Instant::now();
 
     let client = AwsClient::new(aws_config.clone())?;
-    let sm = client.secrets_manager();
 
-    for (arn, value) in secure_arns.iter_mut() {
-        // We could look to use the BatchGetSecretValue too
-        match sm.get_secret_value(arn.as_str()).await {
-            Ok(resp) => {
-                if let Some(secret) = resp.secret_string {
-                    *value = secret;
+    let mut arns_by_svc = HashMap::new();
+    for (arn_str, _) in secure_arns.iter() {
+        let arn = arn_str.parse::<AwsArn>()?;
+
+        if arn.service != SECRETS_MANAGER_SERVICE && arn.service != PARAM_STORE_SERVICE {
+            return Err(format!("Unknown secret ARN service name: {}", arn.service).into());
+        }
+
+        // This should never happen, but avoid silent bugs later
+        if arn.to_string() != *arn_str {
+            return Err(format!(
+                "ARN value did not match input string: {} != {}",
+                arn.to_string(),
+                arn_str
+            )
+            .into());
+        }
+
+        arns_by_svc
+            .entry(arn.service.clone())
+            .or_insert_with(|| Vec::new())
+            .push(arn);
+    }
+
+    for (svc, arns) in &arns_by_svc {
+        for arn_chunk in arns.chunks(MAX_LOOKUP_LEN) {
+            if svc == SECRETS_MANAGER_SERVICE {
+                let sm = client.secrets_manager();
+
+                match sm.batch_get_secret(arn_chunk).await {
+                    Ok(res) => {
+                        for (arn, secret) in res {
+                            secure_arns.insert(arn, secret.secret_string);
+                        }
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Unable to resolve ARNs from secrets manager: {:?}: {:?}",
+                            arn_chunk, err,
+                        );
+                        return Err("Unable to resolve ARNs from secrets manager".into());
+                    }
                 }
-            }
-            Err(err) => {
-                warn!(
-                    "Unable to resolve the secrets arn {}: {}, skipping for now",
-                    arn, err
-                );
-                // should this be fatal?
+            } else {
+                let ps = client.parameter_store();
+
+                match ps.get_parameters(arn_chunk).await {
+                    Ok(res) => {
+                        for (arn, param) in res {
+                            secure_arns.insert(arn, param.value);
+                        }
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Unable to resolve ARNs from parameter store: {:?}: {:?}",
+                            arn_chunk, err,
+                        );
+                        return Err("Unable to resolve ARNs from parameter store".into());
+                    }
+                }
             }
         }
     }
@@ -99,7 +146,10 @@ pub async fn resolve_secrets(
 
 #[cfg(test)]
 mod tests {
-    use crate::env::EnvArnParser;
+    use crate::aws_api::config::AwsConfig;
+    use crate::env::{EnvArnParser, resolve_secrets};
+    use crate::test_util::init_crypto;
+    use std::collections::HashMap;
 
     #[test]
     fn test_extract_and_update_arns_from_env() {
@@ -138,5 +188,45 @@ mod tests {
         unsafe { std::env::remove_var("ROTEL_MULTI") }
         unsafe { std::env::remove_var("ROTEL_ALREADY_EXISTS") }
         unsafe { std::env::remove_var("ROTEL_WONT_UPDATE") }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_multiple_secrets() {
+        // TEST_ENVSECRET_ARNS should be set to a comma-separated list of k=v pairs,
+        // where k is an ARN of a secret and v is the secret value to test against.
+        let test_envsecret_arns = std::env::var("TEST_ENVSECRET_ARNS");
+        if !test_envsecret_arns.is_ok() {
+            println!("Skipping test_resolve_multiple_secrets due to unset envvar");
+            return;
+        }
+
+        let test_arns: Vec<(String, String)> = test_envsecret_arns
+            .unwrap()
+            .split(",")
+            .filter(|s| !s.is_empty())
+            .filter_map(|pair| {
+                let parts: Vec<&str> = pair.splitn(2, '=').collect();
+                if parts.len() == 2 {
+                    Some((parts[0].trim().to_string(), parts[1].trim().to_string()))
+                } else {
+                    None // Skip malformed pairs that don't have an equals sign
+                }
+            })
+            .collect();
+
+        init_crypto();
+
+        let mut test_arn_map = HashMap::new();
+        for (test_arn, _) in &test_arns {
+            test_arn_map.insert(test_arn.clone(), "".to_string());
+        }
+
+        let res = resolve_secrets(&AwsConfig::from_env(), &mut test_arn_map).await;
+        assert!(res.is_ok());
+
+        for (test_arn, test_value) in test_arns {
+            let result = test_arn_map.get(&test_arn).unwrap();
+            assert_eq!(test_value, *result);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod aws_api;
 pub mod env;
 pub mod lambda;
 pub mod lifecycle;
+mod test_util;
 pub mod util;

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,13 @@
+use std::sync::Once;
+
+// used for testing
+#[allow(dead_code)]
+static INIT_CRYPTO: Once = Once::new();
+#[allow(dead_code)]
+pub fn init_crypto() {
+    INIT_CRYPTO.call_once(|| {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .unwrap()
+    });
+}


### PR DESCRIPTION
This supports reading values from AWS Secrets Manager (existing) or AWS Parameter Store (new). Instead of looking values one-by-one, which could have large impact on cold start time, we use the batch lookup calls for each service. In theory secrets could be mixed between the two, but that would be a rare use case.

Completes: STR-3336