### PR TITLE
Fix logging otel metrics

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -5,11 +5,31 @@ Prerequisites:
 
 ## Building
 
-To build the project for production, run `cargo lambda build --extension --release`. Remove the `--release` flag to build for development.
+```shell
+make build
+```
+
+This will perform a release build of the extension. 
 
 Read more about building your lambda extension in [the Cargo Lambda documentation](https://www.cargo-lambda.info/commands/build.html#extensions).
 
-## Deploy and Publish
+## Deploy testing
+
+If you want to test a deployment, you can use the following command. By default it will publish as the layer name `rotel-extension-test`. 
+
+```shell
+make deploy
+```
+
+In order to use the layer in other AWS accounts, you will need to run the following command to publish it. Pass the ARN of the layer output from the above command as an argument.
+
+```shell
+ ./scripts/publish-lambda-version.sh arn:aws:lambda:us-east-1:999999999999:layer:rotel-extension-test:29
+```
+
+_You must set the valid AWS CLI credentials in your environment first._ 
+
+## Production Deploy and Publish
 
 When a release is created, the `release.yml` Github action will deploy and publish a new Lambda layer for both x86-64 and arm64 architectures.
 The layer will be published to multiple regions, controlled by the regions matrix in the action script.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build test deploy
+
+#
+# These targets are used for local testing, the actual
+# release targets are defined in the Github action files.
+#
+
+DEPLOY_NAME ?= rotel-extension-test
+
+build:
+	cargo lambda build --extension --release
+
+test:
+	cargo nextest run
+
+deploy: build
+	cargo lambda deploy --extension --compatible-runtimes provided.al2023 --binary-name rotel-extension ${DEPLOY_NAME}

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,8 @@ use tokio::time::{Instant, Interval, timeout};
 use tokio::{pin, select};
 use tokio_util::sync::CancellationToken;
 use tower_http::BoxError;
-use tracing::{debug, error, info, warn};
 use tracing::level_filters::LevelFilter;
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
@@ -114,7 +114,7 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    
+
     let agent = opt.agent_args;
     let mut port_map = match bind_endpoints(&[
         agent.otlp_grpc_endpoint,
@@ -523,9 +523,7 @@ fn setup_logging() -> Result<LoggerGuard, BoxError> {
         .with_ansi(false)
         .compact();
 
-    let subscriber = Registry::default()
-        .with(filter)
-        .with(file_layer);
+    let subscriber = Registry::default().with(filter).with(file_layer);
 
     tracing::subscriber::set_global_default(subscriber).unwrap();
     Ok(guard)


### PR DESCRIPTION
Follow on the similar patch to Rotel to block logging output from the opentelemetry crate when setting up internal metrics. This keeps the user's Lambda function output cleaner.

Completes: STR-3351