### PR TITLE
Add badge for release values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,14 @@ The Rotel Lambda Extension integrates with the Lambda [TelemetryAPI](https://doc
 
 ## Using
 
-Choose the Lambda layer that matches your Lambda runtime architecture (**alpha** versions shown):
+Choose the Lambda layer that matches your Lambda runtime architecture (**alpha** versions shown). The `{version}` field
+of the ARN should match the integer value from the latest [release](https://github.com/streamfold/rotel-lambda-extension/releases),
+so the version for `v12-alpha` would be `12`. 
 
-**x86-64/amd64**
-```
-arn:aws:lambda:{region}:418653438961:layer:rotel-extension-amd64-alpha:{version}
-```
-
-**arm64** 
-```
-arn:aws:lambda:{region}:418653438961:layer:rotel-extension-arm64-alpha:{version}
-```
+| Architecture | ARN                                                                              | Version                                                                                                                            |
+|--------------|----------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| x86-64/amd64 | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-amd64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&cacheSeconds=600) |
+| arm64        | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-arm64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&cacheSeconds=600) |
 
 The layer is deployed in the following AWS regions (if you don't see yours, let us know!):
 - us-east-{1, 2}, us-west-{1, 2}
@@ -33,10 +30,6 @@ The layer is deployed in the following AWS regions (if you don't see yours, let 
 The layer supports the Amazon Linux 2023
 [Lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported)
 (`provided.al2023`).
-
-The _{version}_ field should match the integer value for the latest release on the
-[Releases](https://github.com/streamfold/rotel-lambda-extension/releases) page,
-for example `v12-alpha` should use `12` as the version.
 
 ## Auto instrumentation
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Choose the Lambda layer that matches your Lambda runtime architecture (**alpha**
 of the ARN should match the integer value from the latest [release](https://github.com/streamfold/rotel-lambda-extension/releases),
 so the version for `v12-alpha` would be `12`. 
 
-| Architecture | ARN                                                                              | Version                                                                                                                            |
-|--------------|----------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| x86-64/amd64 | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-amd64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&cacheSeconds=600) |
-| arm64        | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-arm64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&cacheSeconds=600) |
+| Architecture | ARN                                                                              | Version                                                                                                                                                                 |
+|--------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| x86-64/amd64 | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-amd64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&labelColor=%2338BDF8&color=%23312E81&cacheSeconds=600) |
+| arm64        | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-arm64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&labelColor=%2338BDF8&color=%23312E81&cacheSeconds=600) |
 
 The layer is deployed in the following AWS regions (if you don't see yours, let us know!):
 - us-east-{1, 2}, us-west-{1, 2}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Choose the Lambda layer that matches your Lambda runtime architecture (**alpha**
 of the ARN should match the integer value from the latest [release](https://github.com/streamfold/rotel-lambda-extension/releases),
 so the version for `v12-alpha` would be `12`. 
 
-| Architecture | ARN                                                                              | Version                                                                                                                                                                 |
-|--------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| x86-64/amd64 | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-amd64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&labelColor=%2338BDF8&color=%23312E81&cacheSeconds=600) |
-| arm64        | arn:aws:lambda:{region}:418653438961:layer:rotel-extension-arm64-alpha:{version} | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&labelColor=%2338BDF8&color=%23312E81&cacheSeconds=600) |
+| Architecture | ARN                                                                                | Version                                                                                                                                                                 |
+|--------------|------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| x86-64/amd64 | `arn:aws:lambda:{region}:418653438961:layer:rotel-extension-amd64-alpha:{version}` | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&labelColor=%2338BDF8&color=%23312E81&cacheSeconds=600) |
+| arm64        | `arn:aws:lambda:{region}:418653438961:layer:rotel-extension-arm64-alpha:{version}` | ![Version](https://img.shields.io/github/v/release/streamfold/rotel-lambda-extension?filter=*alpha&label=version&labelColor=%2338BDF8&color=%23312E81&cacheSeconds=600) |
 
 The layer is deployed in the following AWS regions (if you don't see yours, let us know!):
 - us-east-{1, 2}, us-west-{1, 2}


### PR DESCRIPTION
Use a badge to inline the latest release number into the ARN table. We could also consider [globadge](https://www.globadge.com/badges/serverless), but the serverless options don't appear to working. Shields appears to be a bit more supported for general Github metadata badges.

Resolves: #41 