### PR TITLE
Release: Bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "rotel-extension"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rotel-extension"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 homepage = "https://github.com/streamfold/rotel-lambda-extension"
 readme = "README.md"


### PR DESCRIPTION
This PR bumps the version from 0.1.2 to 0.1.3.

**Bump type:** patch

After merging this PR, a tag `v0.1.3` will be automatically created and pushed, which will trigger the release workflow.

If you want to prevent automatic tagging, add the `no-auto-tag` label to this PR before merging.