### PR TITLE
Release: Bump version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "rotel-extension"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rotel-extension"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 homepage = "https://github.com/streamfold/rotel-lambda-extension"
 readme = "README.md"


### PR DESCRIPTION
This PR bumps the version from 0.1.4 to 0.1.5.

**Bump type:** patch

After merging this PR, a tag `v0.1.5` will be automatically created and pushed, which will trigger the release workflow.

If you want to prevent automatic tagging, add the `no-auto-tag` label to this PR before merging.